### PR TITLE
feat : WorkRecord엔티티 생성

### DIFF
--- a/src/main/java/upqnu/scwhim/ScwhimApplication.java
+++ b/src/main/java/upqnu/scwhim/ScwhimApplication.java
@@ -2,8 +2,10 @@ package upqnu.scwhim;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ScwhimApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/upqnu/scwhim/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/controller/EmployeeController.java
@@ -1,15 +1,15 @@
-package upqnu.scwhim.employee.controller;
+package upqnu.scwhim.domain.employee.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import upqnu.scwhim.employee.dto.EmployeeInfoResDto;
-import upqnu.scwhim.employee.dto.EmployeeJoinReqDto;
-import upqnu.scwhim.employee.dto.EmployeeModifyReqDto;
-import upqnu.scwhim.employee.dto.EmployeePositionReqDto;
-import upqnu.scwhim.employee.service.EmployeeService;
+import upqnu.scwhim.domain.employee.dto.EmployeeInfoResDto;
+import upqnu.scwhim.domain.employee.dto.EmployeeModifyReqDto;
+import upqnu.scwhim.domain.employee.service.EmployeeService;
+import upqnu.scwhim.domain.employee.dto.EmployeeJoinReqDto;
+import upqnu.scwhim.domain.employee.dto.EmployeePositionReqDto;
 
 import java.util.List;
 

--- a/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeeInfoResDto.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeeInfoResDto.java
@@ -1,9 +1,8 @@
-package upqnu.scwhim.employee.dto;
+package upqnu.scwhim.domain.employee.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import upqnu.scwhim.employee.entity.Role;
-import upqnu.scwhim.team.entity.Team;
+import upqnu.scwhim.domain.employee.entity.Role;
 
 import java.time.LocalDate;
 

--- a/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeeJoinReqDto.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeeJoinReqDto.java
@@ -1,4 +1,4 @@
-package upqnu.scwhim.employee.dto;
+package upqnu.scwhim.domain.employee.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeeModifyReqDto.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeeModifyReqDto.java
@@ -1,4 +1,4 @@
-package upqnu.scwhim.employee.dto;
+package upqnu.scwhim.domain.employee.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeePositionReqDto.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/dto/EmployeePositionReqDto.java
@@ -1,9 +1,9 @@
-package upqnu.scwhim.employee.dto;
+package upqnu.scwhim.domain.employee.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import upqnu.scwhim.employee.entity.Role;
+import upqnu.scwhim.domain.employee.entity.Role;
 
 @Getter
 @Setter

--- a/src/main/java/upqnu/scwhim/domain/employee/entity/Employee.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/entity/Employee.java
@@ -1,16 +1,20 @@
-package upqnu.scwhim.employee.entity;
+package upqnu.scwhim.domain.employee.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import upqnu.scwhim.team.entity.Team;
+import upqnu.scwhim.domain.team.entity.Team;
+import upqnu.scwhim.domain.workrecord.entity.WorkRecord;
+import upqnu.scwhim.global.BaseEntity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Employee {
+public class Employee extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +37,9 @@ public class Employee {
     @ManyToOne
     @JoinColumn(name = "team_id")
     private Team team;
+
+    @OneToMany(mappedBy = "employee")
+    private List<WorkRecord> workRecordList = new ArrayList<>();
 
     public Employee(String name, LocalDate workstartDate, LocalDate birthday) {
         this.name = name;

--- a/src/main/java/upqnu/scwhim/domain/employee/entity/Role.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/entity/Role.java
@@ -1,4 +1,4 @@
-package upqnu.scwhim.employee.entity;
+package upqnu.scwhim.domain.employee.entity;
 
 import lombok.Getter;
 

--- a/src/main/java/upqnu/scwhim/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/repository/EmployeeRepository.java
@@ -1,7 +1,7 @@
-package upqnu.scwhim.employee.repository;
+package upqnu.scwhim.domain.employee.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import upqnu.scwhim.employee.entity.Employee;
+import upqnu.scwhim.domain.employee.entity.Employee;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 

--- a/src/main/java/upqnu/scwhim/domain/employee/service/EmployeeService.java
+++ b/src/main/java/upqnu/scwhim/domain/employee/service/EmployeeService.java
@@ -1,16 +1,16 @@
-package upqnu.scwhim.employee.service;
+package upqnu.scwhim.domain.employee.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import upqnu.scwhim.employee.dto.EmployeeInfoResDto;
-import upqnu.scwhim.employee.dto.EmployeeJoinReqDto;
-import upqnu.scwhim.employee.dto.EmployeeModifyReqDto;
-import upqnu.scwhim.employee.dto.EmployeePositionReqDto;
-import upqnu.scwhim.employee.entity.Employee;
-import upqnu.scwhim.employee.repository.EmployeeRepository;
-import upqnu.scwhim.team.entity.Team;
-import upqnu.scwhim.team.repository.TeamRepository;
+import upqnu.scwhim.domain.employee.dto.EmployeeInfoResDto;
+import upqnu.scwhim.domain.employee.dto.EmployeeModifyReqDto;
+import upqnu.scwhim.domain.employee.repository.EmployeeRepository;
+import upqnu.scwhim.domain.employee.dto.EmployeeJoinReqDto;
+import upqnu.scwhim.domain.employee.dto.EmployeePositionReqDto;
+import upqnu.scwhim.domain.employee.entity.Employee;
+import upqnu.scwhim.domain.team.entity.Team;
+import upqnu.scwhim.domain.team.repository.TeamRepository;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/upqnu/scwhim/domain/team/controller/TeamController.java
+++ b/src/main/java/upqnu/scwhim/domain/team/controller/TeamController.java
@@ -1,13 +1,13 @@
-package upqnu.scwhim.team.controller;
+package upqnu.scwhim.domain.team.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import upqnu.scwhim.team.dto.TeamInfoResponse;
-import upqnu.scwhim.team.dto.TeamRegisterReqDto;
-import upqnu.scwhim.team.service.TeamService;
+import upqnu.scwhim.domain.team.dto.TeamInfoResponse;
+import upqnu.scwhim.domain.team.dto.TeamRegisterReqDto;
+import upqnu.scwhim.domain.team.service.TeamService;
 
 import java.util.List;
 

--- a/src/main/java/upqnu/scwhim/domain/team/dto/TeamInfoResponse.java
+++ b/src/main/java/upqnu/scwhim/domain/team/dto/TeamInfoResponse.java
@@ -1,11 +1,7 @@
-package upqnu.scwhim.team.dto;
+package upqnu.scwhim.domain.team.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
-import upqnu.scwhim.employee.entity.Employee;
-
-import java.util.List;
 
 @Getter
 //@Setter

--- a/src/main/java/upqnu/scwhim/domain/team/dto/TeamRegisterReqDto.java
+++ b/src/main/java/upqnu/scwhim/domain/team/dto/TeamRegisterReqDto.java
@@ -1,4 +1,4 @@
-package upqnu.scwhim.team.dto;
+package upqnu.scwhim.domain.team.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/src/main/java/upqnu/scwhim/domain/team/entity/Team.java
+++ b/src/main/java/upqnu/scwhim/domain/team/entity/Team.java
@@ -1,9 +1,10 @@
-package upqnu.scwhim.team.entity;
+package upqnu.scwhim.domain.team.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import upqnu.scwhim.employee.entity.Employee;
+import upqnu.scwhim.domain.employee.entity.Employee;
+import upqnu.scwhim.global.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Team {
+public class Team extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/upqnu/scwhim/domain/team/repository/TeamRepository.java
+++ b/src/main/java/upqnu/scwhim/domain/team/repository/TeamRepository.java
@@ -1,7 +1,7 @@
-package upqnu.scwhim.team.repository;
+package upqnu.scwhim.domain.team.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import upqnu.scwhim.team.entity.Team;
+import upqnu.scwhim.domain.team.entity.Team;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 

--- a/src/main/java/upqnu/scwhim/domain/team/service/TeamService.java
+++ b/src/main/java/upqnu/scwhim/domain/team/service/TeamService.java
@@ -1,16 +1,16 @@
-package upqnu.scwhim.team.service;
+package upqnu.scwhim.domain.team.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import upqnu.scwhim.employee.entity.Employee;
-import upqnu.scwhim.employee.repository.EmployeeRepository;
-import upqnu.scwhim.team.dto.TeamInfoResponse;
-import upqnu.scwhim.team.dto.TeamRegisterReqDto;
-import upqnu.scwhim.team.entity.Team;
-import upqnu.scwhim.team.repository.TeamRepository;
+import upqnu.scwhim.domain.employee.entity.Employee;
+import upqnu.scwhim.domain.employee.repository.EmployeeRepository;
+import upqnu.scwhim.domain.team.entity.Team;
+import upqnu.scwhim.domain.team.dto.TeamInfoResponse;
+import upqnu.scwhim.domain.team.dto.TeamRegisterReqDto;
+import upqnu.scwhim.domain.team.repository.TeamRepository;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/upqnu/scwhim/domain/workrecord/entity/WorkRecord.java
+++ b/src/main/java/upqnu/scwhim/domain/workrecord/entity/WorkRecord.java
@@ -1,0 +1,26 @@
+package upqnu.scwhim.domain.workrecord.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import upqnu.scwhim.domain.employee.entity.Employee;
+import upqnu.scwhim.global.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "work_record")
+@Getter
+@NoArgsConstructor
+public class WorkRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime punchInTime;
+
+    private LocalDateTime goHomeTime;
+
+    @ManyToOne
+    private Employee employee;
+}

--- a/src/main/java/upqnu/scwhim/global/BaseEntity.java
+++ b/src/main/java/upqnu/scwhim/global/BaseEntity.java
@@ -1,0 +1,31 @@
+package upqnu.scwhim.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+//    @CreatedBy
+//    @Column(updatable = false)
+//    private String createdBy;
+//
+//    @LastModifiedBy
+//    private String modifiedBy;
+}


### PR DESCRIPTION
- 특정 레코드 생성일시 및 수정일시 자동기록을 위해 JPA audit을 활용한 BaseEntity 추상클래스 생성
- 출퇴근 기록 및 근무시간 계산을 위한 WorkRecord 엔티티 생성
- Employee, Team 및 WorkRecord 엔티티 모두 BaseEntity 상속(extends)